### PR TITLE
bugfix: change SkeletonItem width rendering

### DIFF
--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -3,11 +3,11 @@ import SkeletonItem from "./SkeletonItem";
 function Skeleton() {
     return (
         <ul className="skeleton animate-pulse w-full pt-6">
-            <SkeletonItem width="450" />
-            <SkeletonItem width="650" />
-            <SkeletonItem width="230" />
-            <SkeletonItem width="180" />
-            <SkeletonItem width="350" />
+            <SkeletonItem width="w-[450px]" />
+            <SkeletonItem width="w-[650px]" />
+            <SkeletonItem width="w-[230px]" />
+            <SkeletonItem width="w-[180px]" />
+            <SkeletonItem width="w-[350px]" />
         </ul>
     );
 }

--- a/src/components/Skeleton/SkeletonItem.tsx
+++ b/src/components/Skeleton/SkeletonItem.tsx
@@ -2,7 +2,7 @@ function SkeletonItem ({ ...props }) {
     return (
         <li className="flex mb-3 h-4">
             <div className="w-4 rounded-[3px] mr-4 bg-gray-200"></div>
-            <div className={`w-[${props.width}px] rounded-[3px] bg-gray-200 mr-3`}></div>
+            <div className={`${ props.width } rounded-[3px] bg-gray-200 mr-3`}></div>
         </li>
     );
 }


### PR DESCRIPTION
Previous format did compile width on tailwind wrongly