### PR TITLE
Troca o termo "festa" por "corrida" no texto de usuário

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Quando uma entrega acopla banco + metadata + código:
   verde-água `#2ec4b6`, laranja `#ff8a3d`, amarelo `#ffd24a`; títulos Lilita
   One levemente rotacionados, corpo Rubik. Tokens no `tailwind.config.js` —
   usar os nomes (`palco`, `agua`, `laranja`...), não hex solto.
-- Vocabulário do produto em texto de usuário: evento é **"festa"**, inscrição é
+- Vocabulário do produto em texto de usuário: evento é **"corrida"**, inscrição é
   **"entrar na pista"**, conclusão com foto é **"cunhar a medalha"**, a página
   do evento tem o **"mural de medalhas"**. Tom celebratório, pt-BR informal.
   Identificadores de código/banco ficam neutros (`events`, `registrations`).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VirtuRace 🏅
 
-App de corrida virtual com alma de festival de rua: crie "festas" (eventos de
+App de corrida virtual com alma de festival de rua: crie "corridas" (eventos de
 corrida), entre na pista, corra onde estiver e cunhe sua medalha enviando uma
 foto de conclusão.
 
@@ -36,7 +36,7 @@ objetos guardando só a URL.
 api/            funções serverless da Vercel (auth)
 hasura/         schema.sql (Neon) + metadata.json (permissões) + docs
 src/api/        client GraphQL e chamadas (events, registrations, session)
-src/pages/      Login, Festas, Criar, Detalhe (+ mural), Minhas medalhas
+src/pages/      Login, Corridas, Criar, Detalhe (+ mural), Minhas medalhas
 docs/SETUP.md   guia de provisionamento sem terminal
 ```
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -64,7 +64,7 @@ Dá para gerar em <https://www.random.org/passwords/?num=2&len=24&format=plain>
    > nos tokens que as funções assinam.
 
 3. Clique **Deploy**. Ao final, abra a URL gerada: a tela "Bora correr por
-   aí?" deve carregar. Crie sua conta, monte uma festa e teste o fluxo
+   aí?" deve carregar. Crie sua conta, monte uma corrida e teste o fluxo
    completo (inscrição → foto → medalha).
 
 ## Problemas comuns
@@ -72,7 +72,7 @@ Dá para gerar em <https://www.random.org/passwords/?num=2&len=24&format=plain>
 - **"Erro inesperado" ao entrar/cadastrar** → confira `HASURA_ENDPOINT`,
   `HASURA_ADMIN_SECRET` e `JWT_SECRET` na Vercel (Settings → Environment
   Variables) e faça **Redeploy** depois de alterar.
-- **Login funciona mas as festas não carregam (JWT inválido)** → o
+- **Login funciona mas as corridas não carregam (JWT inválido)** → o
   `HASURA_GRAPHQL_JWT_SECRET` do Hasura não bate com o `JWT_SECRET` da
   Vercel, ou não é um JSON válido.
 - **Import de metadata falhou** → verifique se a env `PG_DATABASE_URL`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ export default function App() {
           }
         />
         <Route
-          path="/festa/:id"
+          path="/corrida/:id"
           element={
             <RequireAuth>
               <EventDetail />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -25,10 +25,10 @@ export default function Header() {
       </Link>
       <div className="flex flex-wrap gap-1.5">
         <NavLink to="/" end className={tabClass}>
-          Festas
+          Corridas
         </NavLink>
         <NavLink to="/criar" className={tabClass}>
-          Criar festa
+          Criar corrida
         </NavLink>
         <NavLink to="/medalhas" className={tabClass}>
           Minhas medalhas

--- a/src/index.css
+++ b/src/index.css
@@ -25,18 +25,18 @@ body {
     @apply text-papel;
   }
 
-  .btn-festa {
+  .btn-corrida {
     @apply inline-block cursor-pointer rounded-full bg-laranja px-6 py-2.5 font-display text-lg tracking-wide transition-transform;
     color: #3c1a00;
     transform: rotate(-1deg);
   }
-  .btn-festa:hover:not(:disabled) {
+  .btn-corrida:hover:not(:disabled) {
     transform: rotate(-1deg) scale(1.04);
   }
-  .btn-festa:disabled {
+  .btn-corrida:disabled {
     @apply cursor-wait opacity-60;
   }
-  .btn-festa--agua {
+  .btn-corrida--agua {
     @apply bg-agua text-agua-escuro;
   }
 
@@ -47,15 +47,15 @@ body {
     @apply mb-1.5 mt-4 block text-[0.8rem] font-semibold text-papel-suave;
   }
 
-  .chip-festa {
+  .chip-corrida {
     @apply whitespace-nowrap rounded-full bg-black/25 px-3 py-1 text-xs font-semibold text-white;
   }
-  .chip-festa--sol {
+  .chip-corrida--sol {
     @apply bg-amarelo text-amarelo-ink;
     transform: rotate(2deg);
   }
 
-  .titulo-festa {
+  .titulo-corrida {
     @apply my-3 font-display text-4xl sm:text-[2.6rem];
     transform: rotate(-1.2deg);
     text-wrap: balance;
@@ -85,8 +85,8 @@ body {
   .confete {
     display: none;
   }
-  .btn-festa,
-  .btn-festa:hover:not(:disabled) {
+  .btn-corrida,
+  .btn-corrida:hover:not(:disabled) {
     transition: none;
     transform: none;
   }

--- a/src/pages/EventCreate.tsx
+++ b/src/pages/EventCreate.tsx
@@ -32,17 +32,17 @@ export default function EventCreate() {
         endDate,
       });
       queryClient.invalidateQueries({ queryKey: ['events'] });
-      navigate(`/festa/${id}`);
+      navigate(`/corrida/${id}`);
     } catch (err) {
-      setError(gqlErrorMessage(err, 'Não foi possível criar a festa agora.'));
+      setError(gqlErrorMessage(err, 'Não foi possível criar a corrida agora.'));
       setLoading(false);
     }
   }
 
   return (
     <main className="mx-auto max-w-4xl px-5 pb-20 pt-4">
-      <h1 className="titulo-festa">
-        Monta a <span className="text-laranja">tua festa</span>
+      <h1 className="titulo-corrida">
+        Monta a <span className="text-laranja">tua corrida</span>
       </h1>
       <p className="mb-7 max-w-lg text-papel-suave">
         Invente a corrida: uma distância, um período, um convite. A turma faz o
@@ -121,7 +121,7 @@ export default function EventCreate() {
 
         {error && <p className="mt-3 text-sm text-[#ff6b6b]">{error}</p>}
 
-        <button type="submit" disabled={loading} className="btn-festa mt-5">
+        <button type="submit" disabled={loading} className="btn-corrida mt-5">
           {loading ? 'Subindo o palco...' : 'Soltar o cartaz 🎉'}
         </button>
       </form>

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -40,7 +40,7 @@ export default function EventDetail() {
   if (isPending) {
     return (
       <main className="mx-auto max-w-4xl px-5 pt-6">
-        <p className="text-papel-suave">Carregando a festa...</p>
+        <p className="text-papel-suave">Carregando a corrida...</p>
       </main>
     );
   }
@@ -48,10 +48,10 @@ export default function EventDetail() {
     return (
       <main className="mx-auto max-w-4xl px-5 pt-6">
         <p className="text-[#ff6b6b]">
-          {error ? gqlErrorMessage(error) : 'Festa não encontrada.'}
+          {error ? gqlErrorMessage(error) : 'Corrida não encontrada.'}
         </p>
         <Link to="/" className="font-semibold text-agua underline">
-          ← Todas as festas
+          ← Todas as corridas
         </Link>
       </main>
     );
@@ -69,11 +69,11 @@ export default function EventDetail() {
         to="/"
         className="text-sm font-semibold text-agua no-underline hover:underline"
       >
-        ← Todas as festas
+        ← Todas as corridas
       </Link>
 
       <div className={`${posterGradient(gradIndex)} mt-3.5 rounded-3xl p-7`}>
-        <span className="chip-festa">{formatKm(data.distanceKm)}</span>
+        <span className="chip-corrida">{formatKm(data.distanceKm)}</span>
         <h1 className="my-2 -rotate-1 font-display text-3xl sm:text-4xl">
           {data.name}
         </h1>
@@ -111,7 +111,7 @@ export default function EventDetail() {
             type="button"
             onClick={handleSubscribe}
             disabled={subscribing}
-            className="btn-festa btn-festa--agua"
+            className="btn-corrida btn-corrida--agua"
           >
             {subscribing ? 'Entrando...' : 'Entrar na pista 🎉'}
           </button>
@@ -141,7 +141,7 @@ export default function EventDetail() {
 
         {data.creatorName && (
           <p className="mt-4 text-xs opacity-80">
-            Festa organizada por {firstName(data.creatorName)}
+            Corrida organizada por {firstName(data.creatorName)}
           </p>
         )}
       </div>

--- a/src/pages/EventList.tsx
+++ b/src/pages/EventList.tsx
@@ -15,20 +15,20 @@ export default function EventList() {
 
   return (
     <main className="mx-auto max-w-4xl px-5 pb-20 pt-4">
-      <h1 className="titulo-festa">
-        Festas na <span className="text-laranja">pista</span>
+      <h1 className="titulo-corrida">
+        Corridas na <span className="text-laranja">pista</span>
       </h1>
       <p className="mb-7 max-w-lg text-papel-suave">
         Escolha uma corrida, entre na pista e corra onde você estiver. No final,
         sua foto vira medalha.
       </p>
 
-      {isPending && <p className="text-papel-suave">Carregando as festas...</p>}
+      {isPending && <p className="text-papel-suave">Carregando as corridas...</p>}
       {error && <p className="text-[#ff6b6b]">{gqlErrorMessage(error)}</p>}
 
       {data && data.length === 0 && (
         <p className="text-papel-suave">
-          Nenhuma festa por enquanto.{' '}
+          Nenhuma corrida por enquanto.{' '}
           <Link to="/criar" className="font-semibold text-agua underline">
             Monta a primeira?
           </Link>
@@ -41,7 +41,7 @@ export default function EventList() {
             <button
               key={event.id}
               type="button"
-              onClick={() => navigate(`/festa/${event.id}`)}
+              onClick={() => navigate(`/corrida/${event.id}`)}
               className={`${posterGradient(i)} flex min-h-[150px] flex-col gap-2 rounded-[20px] p-5 text-left transition-transform hover:-rotate-1 hover:scale-[1.015] motion-reduce:transform-none`}
             >
               <h3 className="font-display text-xl leading-tight">
@@ -52,17 +52,17 @@ export default function EventList() {
                 {formatDate(event.endDate)}
               </span>
               <span className="mt-auto flex flex-wrap items-center gap-2">
-                <span className="chip-festa">
+                <span className="chip-corrida">
                   {event.registrationCount} na pista
                 </span>
                 {event.completedCount > 0 && (
-                  <span className="chip-festa chip-festa--sol">
+                  <span className="chip-corrida chip-corrida--sol">
                     🏅 {event.completedCount} medalha
                     {event.completedCount > 1 ? 's' : ''}
                   </span>
                 )}
                 {event.amRegistered && (
-                  <span className="chip-festa">você tá dentro ✓</span>
+                  <span className="chip-corrida">você tá dentro ✓</span>
                 )}
               </span>
             </button>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -39,7 +39,7 @@ export default function Login() {
         <span className="inline-block -rotate-2 font-display text-4xl text-amarelo">
           VirtuRace
         </span>
-        <h1 className="titulo-festa mt-1 text-center">
+        <h1 className="titulo-corrida mt-1 text-center">
           Bora correr <span className="text-laranja">por aí?</span>
         </h1>
         <p className="mx-auto max-w-md text-papel-suave">
@@ -99,12 +99,12 @@ export default function Login() {
         <button
           type="submit"
           disabled={loading}
-          className="btn-festa mt-5 w-full"
+          className="btn-corrida mt-5 w-full"
         >
           {loading
             ? 'Aguenta aí...'
             : mode === 'entrar'
-              ? 'Entrar na festa'
+              ? 'Entrar na corrida'
               : 'Criar minha conta 🎉'}
         </button>
 

--- a/src/pages/MyMedals.tsx
+++ b/src/pages/MyMedals.tsx
@@ -60,7 +60,7 @@ export default function MyMedals() {
 
   return (
     <main className="mx-auto max-w-4xl px-5 pb-20 pt-4">
-      <h1 className="titulo-festa">
+      <h1 className="titulo-corrida">
         Minhas <span className="text-laranja">medalhas</span>
       </h1>
       <p className="mb-7 max-w-lg text-papel-suave">
@@ -80,7 +80,7 @@ export default function MyMedals() {
         <p className="text-papel-suave">
           Você ainda não entrou em nenhuma corrida.{' '}
           <Link to="/" className="font-semibold text-agua underline">
-            Escolhe uma festa
+            Escolhe uma corrida
           </Link>{' '}
           e bora!
         </p>
@@ -98,7 +98,7 @@ export default function MyMedals() {
                 <div className="min-w-[190px] flex-1">
                   <h3 className="font-display text-lg">
                     <Link
-                      to={`/festa/${reg.event.id}`}
+                      to={`/corrida/${reg.event.id}`}
                       className="text-papel no-underline hover:text-amarelo"
                     >
                       {reg.event.name}
@@ -135,7 +135,7 @@ export default function MyMedals() {
                     caption={`em ${formatDate(reg.completedAt)}`}
                   />
                 ) : (
-                  <label className="btn-festa cursor-pointer text-base">
+                  <label className="btn-corrida cursor-pointer text-base">
                     {uploadingId === reg.id
                       ? 'Cunhando...'
                       : '📷 Cunhar minha medalha'}


### PR DESCRIPTION
O produto é uma corrida virtual; "festa" era o termo antigo do vocabulário
de evento. Substitui em todo texto de usuário, na rota /festa/:id → /corrida/:id
e nas classes CSS (btn-festa/chip-festa/titulo-festa → *-corrida). Atualiza
CLAUDE.md, README e SETUP para refletir o vocabulário novo. "Festival de Rua"
(direção visual) fica intacto.

Verificação: npm ci, npm run build e npm run lint passam.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TqYMC2cebnBcFSzVGJyJqn