### PR TITLE
Conserta quebra do cabeçalho no mobile

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,14 +16,29 @@ export default function Header() {
   if (!user) return null;
 
   return (
-    <nav className="mx-auto flex max-w-4xl flex-wrap items-center gap-2.5 px-5 py-3.5">
-      <Link
-        to="/"
-        className="mr-1.5 inline-block -rotate-2 font-display text-2xl text-amarelo no-underline"
-      >
-        VirtuRace
-      </Link>
-      <div className="flex flex-wrap gap-1.5">
+    <nav className="mx-auto max-w-4xl px-5 py-3.5">
+      <div className="flex items-center gap-2.5">
+        <Link
+          to="/"
+          className="mr-auto inline-block -rotate-2 font-display text-2xl text-amarelo no-underline"
+        >
+          VirtuRace
+        </Link>
+        <span className="hidden text-sm text-papel-suave sm:inline">
+          Oi, {firstName(user.name)}!
+        </span>
+        <button
+          type="button"
+          onClick={() => {
+            signOut();
+            navigate('/login');
+          }}
+          className="shrink-0 rounded-full border border-roxo-claro px-3.5 py-1.5 text-sm font-semibold text-papel-suave hover:border-agua hover:text-agua"
+        >
+          Sair
+        </button>
+      </div>
+      <div className="mt-2.5 flex flex-wrap gap-1.5">
         <NavLink to="/" end className={tabClass}>
           Corridas
         </NavLink>
@@ -33,19 +48,6 @@ export default function Header() {
         <NavLink to="/medalhas" className={tabClass}>
           Minhas medalhas
         </NavLink>
-      </div>
-      <div className="ml-auto flex items-center gap-2.5 text-sm text-papel-suave">
-        <span className="hidden sm:inline">Oi, {firstName(user.name)}!</span>
-        <button
-          type="button"
-          onClick={() => {
-            signOut();
-            navigate('/login');
-          }}
-          className="rounded-full border border-roxo-claro px-3.5 py-1.5 text-sm font-semibold text-papel-suave hover:border-agua hover:text-agua"
-        >
-          Sair
-        </button>
       </div>
     </nav>
   );


### PR DESCRIPTION
## O que muda

O cabeçalho quebrava no mobile: com os itens de nav mais largos ("Corridas"/"Criar corrida"), o layout de linha única com `flex-wrap` empurrava o botão "Sair" para uma linha solta. Reestrutura o header em duas linhas:

- Linha 1: marca `VirtuRace` à esquerda, saudação ("Oi, nome!", só no desktop) e botão "Sair" à direita.
- Linha 2: as três abas (Corridas / Criar corrida / Minhas medalhas), que cabem numa linha no mobile e quebram como grupo se faltar espaço.

## Arquivos

- `src/components/Header.tsx`

## Como verificar

- `npm run build` e `npm run lint` passam.
- Screenshot headless conferido em 412px (mobile) e 900px (desktop): sem "Sair" solto, abas alinhadas.
- Sem mudança de banco/metadata — só front; deploy da Vercel resolve no merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqYMC2cebnBcFSzVGJyJqn)_