### PR TITLE
Modalidades por corrida (caminhada/corrida, várias distâncias)

### DIFF
--- a/hasura/README.md
+++ b/hasura/README.md
@@ -18,7 +18,13 @@ O passo a passo completo (com a ordem certa e as env vars) está em
   - `users`: lê só `id` e `name` de qualquer pessoa (para o mural). E-mail e
     hash de senha nunca saem pelo GraphQL — só as funções de auth (admin) os tocam.
   - `events`: lê tudo; cria com `created_by` travado no próprio usuário.
+  - `event_modalities`: lê tudo; só insere modalidade em corrida que a própria
+    pessoa criou (`event.created_by`). Uma corrida pode ter várias (caminhada
+    3km, corrida 10km...) — a distância mora aqui, não mais no evento.
   - `registrations`: lê tudo (mural público entre logados); inscreve-se apenas
-    a si mesmo (`user_id` vem da sessão); só atualiza a própria inscrição, só
-    enquanto `registered`, e só para `completed` (com foto/data).
+    a si mesmo (`user_id` vem da sessão) escolhendo uma `modality_id` — o
+    `event_id` é preenchido por trigger a partir da modalidade, então a unique
+    `(event_id, user_id)` mantém "uma pista por corrida por pessoa". Só atualiza
+    a própria inscrição, só enquanto `registered`, e só para `completed` (com
+    foto/data).
 - Sem papel anônimo: toda query exige login.

--- a/hasura/metadata.json
+++ b/hasura/metadata.json
@@ -54,6 +54,15 @@
                     "column": "event_id"
                   }
                 }
+              },
+              {
+                "name": "modalities",
+                "using": {
+                  "foreign_key_constraint_on": {
+                    "table": { "schema": "public", "name": "event_modalities" },
+                    "column": "event_id"
+                  }
+                }
               }
             ],
             "insert_permissions": [
@@ -92,11 +101,55 @@
             ]
           },
           {
+            "table": { "schema": "public", "name": "event_modalities" },
+            "object_relationships": [
+              {
+                "name": "event",
+                "using": { "foreign_key_constraint_on": "event_id" }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "registrations",
+                "using": {
+                  "foreign_key_constraint_on": {
+                    "table": { "schema": "public", "name": "registrations" },
+                    "column": "modality_id"
+                  }
+                }
+              }
+            ],
+            "insert_permissions": [
+              {
+                "role": "runner",
+                "permission": {
+                  "check": {
+                    "event": { "created_by": { "_eq": "X-Hasura-User-Id" } }
+                  },
+                  "columns": ["event_id", "kind", "distance_km"]
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "runner",
+                "permission": {
+                  "columns": ["id", "event_id", "kind", "distance_km"],
+                  "filter": {}
+                }
+              }
+            ]
+          },
+          {
             "table": { "schema": "public", "name": "registrations" },
             "object_relationships": [
               {
                 "name": "event",
                 "using": { "foreign_key_constraint_on": "event_id" }
+              },
+              {
+                "name": "modality",
+                "using": { "foreign_key_constraint_on": "modality_id" }
               },
               {
                 "name": "user",
@@ -109,7 +162,7 @@
                 "permission": {
                   "check": {},
                   "set": { "user_id": "x-hasura-user-id" },
-                  "columns": ["event_id"]
+                  "columns": ["event_id", "modality_id"]
                 }
               }
             ],

--- a/hasura/schema.sql
+++ b/hasura/schema.sql
@@ -40,6 +40,67 @@ create table if not exists public.registrations (
   constraint registrations_one_per_event unique (event_id, user_id)
 );
 
+-- Modalidades da corrida: uma prova pode ter várias (caminhada 3km, corrida
+-- 10km...). A distância mora aqui, não mais no evento. `events.distance_km`
+-- vira legado (ver alteração abaixo) — nada novo escreve nela.
+create table if not exists public.event_modalities (
+  id uuid primary key default gen_random_uuid(),
+  event_id uuid not null references public.events (id) on delete cascade,
+  kind text not null check (kind in ('walk', 'run')),
+  distance_km numeric not null check (distance_km > 0),
+  created_at timestamptz not null default now()
+);
+
+-- Distância deixou de ser do evento; solta o not null para não travar inserts
+-- do novo fluxo (sem quebrar linhas antigas, que continuam preenchidas).
+alter table public.events alter column distance_km drop not null;
+
+-- Cada inscrição escolhe uma modalidade. Fica anulável de propósito: linhas
+-- antigas (e a janela de deploy entre metadata e código) não têm modalidade.
+alter table public.registrations
+  add column if not exists modality_id uuid
+    references public.event_modalities (id) on delete set null;
+
+-- Backfill: todo evento existente ganha uma modalidade 'run' com a distância
+-- que tinha, e as inscrições apontam para ela. Idempotente (só age no que falta).
+insert into public.event_modalities (event_id, kind, distance_km)
+select e.id, 'run', e.distance_km
+from public.events e
+where e.distance_km is not null
+  and not exists (
+    select 1 from public.event_modalities m where m.event_id = e.id
+  );
+
+update public.registrations r
+set modality_id = m.id
+from public.event_modalities m
+where r.modality_id is null
+  and m.event_id = r.event_id;
+
+-- O `event_id` da inscrição é derivado da modalidade: o cliente manda só
+-- `modality_id` e o trigger preenche o evento, garantindo que casem. Mantém a
+-- unique(event_id, user_id) valendo como "uma pista por corrida por pessoa".
+-- Só age quando há modalidade (o fluxo legado, que manda event_id direto,
+-- continua funcionando na janela de deploy).
+create or replace function public.set_registration_event_id()
+returns trigger language plpgsql as $$
+begin
+  if new.modality_id is not null then
+    select event_id into new.event_id
+    from public.event_modalities
+    where id = new.modality_id;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists registrations_set_event_id on public.registrations;
+create trigger registrations_set_event_id
+  before insert on public.registrations
+  for each row execute function public.set_registration_event_id();
+
 create index if not exists registrations_event_idx on public.registrations (event_id);
 create index if not exists registrations_user_idx on public.registrations (user_id);
+create index if not exists registrations_modality_idx on public.registrations (modality_id);
+create index if not exists event_modalities_event_idx on public.event_modalities (event_id);
 create index if not exists events_start_idx on public.events (start_date);

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -1,5 +1,20 @@
 import { graphqlClient } from './graphql';
-import type { EventDetail, EventSummary } from '../types';
+import type { EventDetail, EventSummary, Modality, ModalityKind } from '../types';
+import { sortModalities } from '../utils';
+
+interface ModalityRow {
+  id: string;
+  kind: string;
+  distance_km: string | number;
+}
+
+function toModality(row: ModalityRow): Modality {
+  return {
+    id: row.id,
+    kind: row.kind === 'walk' ? 'walk' : 'run',
+    distanceKm: Number(row.distance_km),
+  };
+}
 
 const EVENTS_QUERY = `
   query Events {
@@ -7,9 +22,13 @@ const EVENTS_QUERY = `
       id
       name
       description
-      distance_km
       start_date
       end_date
+      modalities {
+        id
+        kind
+        distance_km
+      }
       registrations {
         user_id
         status
@@ -22,9 +41,9 @@ interface EventsRow {
   id: string;
   name: string;
   description: string;
-  distance_km: string | number;
   start_date: string;
   end_date: string;
+  modalities: ModalityRow[];
   registrations: Array<{ user_id: string; status: string }>;
 }
 
@@ -36,7 +55,7 @@ export async function listEvents(myUserId: string): Promise<EventSummary[]> {
     id: row.id,
     name: row.name,
     description: row.description,
-    distanceKm: Number(row.distance_km),
+    modalities: sortModalities(row.modalities.map(toModality)),
     startDate: row.start_date,
     endDate: row.end_date,
     registrationCount: row.registrations.length,
@@ -52,11 +71,15 @@ const EVENT_QUERY = `
       id
       name
       description
-      distance_km
       start_date
       end_date
       creator {
         name
+      }
+      modalities {
+        id
+        kind
+        distance_km
       }
       registrations(order_by: { registered_at: asc }) {
         id
@@ -66,6 +89,11 @@ const EVENT_QUERY = `
         proof_photo
         user {
           name
+        }
+        modality {
+          id
+          kind
+          distance_km
         }
       }
     }
@@ -81,6 +109,7 @@ interface EventRow extends Omit<EventsRow, 'registrations'> {
     completed_at: string | null;
     proof_photo: string | null;
     user: { name: string } | null;
+    modality: ModalityRow | null;
   }>;
 }
 
@@ -95,7 +124,7 @@ export async function getEvent(id: string): Promise<EventDetail | null> {
     id: row.id,
     name: row.name,
     description: row.description,
-    distanceKm: Number(row.distance_km),
+    modalities: sortModalities(row.modalities.map(toModality)),
     startDate: row.start_date,
     endDate: row.end_date,
     creatorName: row.creator?.name ?? null,
@@ -106,6 +135,7 @@ export async function getEvent(id: string): Promise<EventDetail | null> {
       status: r.status === 'completed' ? 'completed' : 'registered',
       completedAt: r.completed_at,
       proofPhoto: r.proof_photo,
+      modality: r.modality ? toModality(r.modality) : null,
     })),
   };
 }
@@ -114,17 +144,17 @@ const CREATE_EVENT = `
   mutation CreateEvent(
     $name: String!
     $description: String!
-    $distanceKm: numeric!
     $startDate: date!
     $endDate: date!
+    $modalities: [event_modalities_insert_input!]!
   ) {
     insert_events_one(
       object: {
         name: $name
         description: $description
-        distance_km: $distanceKm
         start_date: $startDate
         end_date: $endDate
+        modalities: { data: $modalities }
       }
     ) {
       id
@@ -132,15 +162,29 @@ const CREATE_EVENT = `
   }
 `;
 
+export interface ModalityInput {
+  kind: ModalityKind;
+  distanceKm: number;
+}
+
 export async function createEvent(input: {
   name: string;
   description: string;
-  distanceKm: number;
   startDate: string;
   endDate: string;
+  modalities: ModalityInput[];
 }): Promise<string> {
   const data = await graphqlClient.request<{
     insert_events_one: { id: string };
-  }>(CREATE_EVENT, input);
+  }>(CREATE_EVENT, {
+    name: input.name,
+    description: input.description,
+    startDate: input.startDate,
+    endDate: input.endDate,
+    modalities: input.modalities.map((m) => ({
+      kind: m.kind,
+      distance_km: m.distanceKm,
+    })),
+  });
   return data.insert_events_one.id;
 }

--- a/src/api/registrations.ts
+++ b/src/api/registrations.ts
@@ -11,10 +11,14 @@ const MY_REGISTRATIONS = `
       status
       completed_at
       proof_photo
+      modality {
+        id
+        kind
+        distance_km
+      }
       event {
         id
         name
-        distance_km
         start_date
         end_date
       }
@@ -27,10 +31,14 @@ interface MyRegRow {
   status: string;
   completed_at: string | null;
   proof_photo: string | null;
+  modality: {
+    id: string;
+    kind: string;
+    distance_km: string | number;
+  } | null;
   event: {
     id: string;
     name: string;
-    distance_km: string | number;
     start_date: string;
     end_date: string;
   };
@@ -48,10 +56,16 @@ export async function listMyRegistrations(
     status: r.status === 'completed' ? 'completed' : 'registered',
     completedAt: r.completed_at,
     proofPhoto: r.proof_photo,
+    modality: r.modality
+      ? {
+          id: r.modality.id,
+          kind: r.modality.kind === 'walk' ? 'walk' : 'run',
+          distanceKm: Number(r.modality.distance_km),
+        }
+      : null,
     event: {
       id: r.event.id,
       name: r.event.name,
-      distanceKm: Number(r.event.distance_km),
       startDate: r.event.start_date,
       endDate: r.event.end_date,
     },
@@ -59,15 +73,15 @@ export async function listMyRegistrations(
 }
 
 const REGISTER = `
-  mutation Register($eventId: uuid!) {
-    insert_registrations_one(object: { event_id: $eventId }) {
+  mutation Register($modalityId: uuid!) {
+    insert_registrations_one(object: { modality_id: $modalityId }) {
       id
     }
   }
 `;
 
-export async function registerForEvent(eventId: string): Promise<void> {
-  await graphqlClient.request(REGISTER, { eventId });
+export async function registerForModality(modalityId: string): Promise<void> {
+  await graphqlClient.request(REGISTER, { modalityId });
 }
 
 const COMPLETE = `

--- a/src/pages/EventCreate.tsx
+++ b/src/pages/EventCreate.tsx
@@ -1,19 +1,49 @@
 import { useState, type FormEvent } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-import { createEvent } from '../api/events';
+import { createEvent, type ModalityInput } from '../api/events';
 import { gqlErrorMessage } from '../api/graphql';
+import type { ModalityKind } from '../types';
+
+interface ModalityDraft {
+  kind: ModalityKind;
+  distanceKm: string;
+}
+
+let modalityKey = 0;
+const newDraft = (kind: ModalityKind, distanceKm: string) => ({
+  key: modalityKey++,
+  draft: { kind, distanceKm } as ModalityDraft,
+});
 
 export default function EventCreate() {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
-  const [distanceKm, setDistanceKm] = useState('5');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
+  const [modalities, setModalities] = useState(() => [
+    newDraft('run', '5'),
+  ]);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+
+  function updateModality(key: number, patch: Partial<ModalityDraft>) {
+    setModalities((rows) =>
+      rows.map((r) =>
+        r.key === key ? { ...r, draft: { ...r.draft, ...patch } } : r
+      )
+    );
+  }
+
+  function addModality() {
+    setModalities((rows) => [...rows, newDraft('run', '')]);
+  }
+
+  function removeModality(key: number) {
+    setModalities((rows) => rows.filter((r) => r.key !== key));
+  }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -22,14 +52,27 @@ export default function EventCreate() {
       setError('A data final precisa ser depois do começo.');
       return;
     }
+    const parsed: ModalityInput[] = [];
+    for (const { draft } of modalities) {
+      const km = Number(draft.distanceKm);
+      if (!Number.isFinite(km) || km <= 0) {
+        setError('Cada modalidade precisa de uma distância maior que zero.');
+        return;
+      }
+      parsed.push({ kind: draft.kind, distanceKm: km });
+    }
+    if (parsed.length === 0) {
+      setError('Adicione pelo menos uma modalidade.');
+      return;
+    }
     setLoading(true);
     try {
       const id = await createEvent({
         name: name.trim(),
         description: description.trim(),
-        distanceKm: Number(distanceKm),
         startDate,
         endDate,
+        modalities: parsed,
       });
       queryClient.invalidateQueries({ queryKey: ['events'] });
       navigate(`/corrida/${id}`);
@@ -45,7 +88,7 @@ export default function EventCreate() {
         Monta a <span className="text-laranja">tua corrida</span>
       </h1>
       <p className="mb-7 max-w-lg text-papel-suave">
-        Invente a corrida: uma distância, um período, um convite. A turma faz o
+        Invente a corrida: as modalidades, um período, um convite. A turma faz o
         resto.
       </p>
 
@@ -77,20 +120,61 @@ export default function EventCreate() {
           required
           placeholder="Conte o clima da corrida — por que vai ser boa?"
         />
-        <label className="rotulo" htmlFor="c-km">
-          Distância (km)
-        </label>
-        <input
-          id="c-km"
-          className="campo"
-          type="number"
-          min="0.5"
-          step="0.1"
-          value={distanceKm}
-          onChange={(e) => setDistanceKm(e.target.value)}
-          required
-        />
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+
+        <span className="rotulo">Modalidades</span>
+        <p className="-mt-1 mb-2 text-xs text-papel-fraco">
+          Caminhada, corrida, várias distâncias — tudo junto na mesma prova.
+        </p>
+        <div className="flex flex-col gap-2.5">
+          {modalities.map(({ key, draft }, i) => (
+            <div key={key} className="flex items-center gap-2">
+              <select
+                aria-label={`Tipo da modalidade ${i + 1}`}
+                className="campo w-auto flex-none"
+                value={draft.kind}
+                onChange={(e) =>
+                  updateModality(key, { kind: e.target.value as ModalityKind })
+                }
+              >
+                <option value="run">🏃 Corrida</option>
+                <option value="walk">🚶 Caminhada</option>
+              </select>
+              <input
+                aria-label={`Distância da modalidade ${i + 1} em km`}
+                className="campo flex-1"
+                type="number"
+                min="0.5"
+                step="0.1"
+                inputMode="decimal"
+                value={draft.distanceKm}
+                onChange={(e) =>
+                  updateModality(key, { distanceKm: e.target.value })
+                }
+                required
+                placeholder="km"
+              />
+              {modalities.length > 1 && (
+                <button
+                  type="button"
+                  onClick={() => removeModality(key)}
+                  aria-label={`Remover modalidade ${i + 1}`}
+                  className="flex-none rounded-full bg-black/25 px-3 py-2 text-sm text-papel hover:bg-black/40"
+                >
+                  ✕
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={addModality}
+          className="mt-2.5 rounded-full border-2 border-roxo-claro px-4 py-1.5 text-sm font-semibold text-papel-suave hover:border-agua hover:text-agua"
+        >
+          + Mais uma modalidade
+        </button>
+
+        <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
           <div>
             <label className="rotulo" htmlFor="c-ini">
               Começa em

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -3,10 +3,16 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useParams } from 'react-router-dom';
 import { getEvent } from '../api/events';
 import { gqlErrorMessage } from '../api/graphql';
-import { registerForEvent } from '../api/registrations';
+import { registerForModality } from '../api/registrations';
 import Medal from '../components/Medal';
 import { useUser } from '../contexts/Auth';
-import { firstName, formatDate, formatKm, posterGradient } from '../utils';
+import {
+  firstName,
+  formatDate,
+  modalityKindEmoji,
+  modalityLabel,
+  posterGradient,
+} from '../utils';
 
 export default function EventDetail() {
   const { id = '' } = useParams<{ id: string }>();
@@ -14,17 +20,22 @@ export default function EventDetail() {
   const queryClient = useQueryClient();
   const [subscribing, setSubscribing] = useState(false);
   const [actionError, setActionError] = useState('');
+  const [chosenModality, setChosenModality] = useState('');
 
   const { data, error, isPending } = useQuery({
     queryKey: ['event', id],
     queryFn: () => getEvent(id),
   });
 
-  async function handleSubscribe() {
+  async function handleSubscribe(modalityId: string) {
+    if (!modalityId) {
+      setActionError('Escolha uma modalidade para entrar na pista.');
+      return;
+    }
     setActionError('');
     setSubscribing(true);
     try {
-      await registerForEvent(id);
+      await registerForModality(modalityId);
       await queryClient.invalidateQueries({ queryKey: ['event', id] });
       queryClient.invalidateQueries({ queryKey: ['events'] });
       queryClient.invalidateQueries({ queryKey: ['myRegistrations'] });
@@ -62,6 +73,9 @@ export default function EventDetail() {
   const gradIndex = data.id
     .split('')
     .reduce((sum, ch) => sum + ch.charCodeAt(0), 0);
+  const soloModality =
+    data.modalities.length === 1 ? data.modalities[0].id : '';
+  const selectedModality = chosenModality || soloModality;
 
   return (
     <main className="mx-auto max-w-4xl px-5 pb-20 pt-4">
@@ -73,7 +87,13 @@ export default function EventDetail() {
       </Link>
 
       <div className={`${posterGradient(gradIndex)} mt-3.5 rounded-3xl p-7`}>
-        <span className="chip-corrida">{formatKm(data.distanceKm)}</span>
+        <div className="flex flex-wrap gap-2">
+          {data.modalities.map((m) => (
+            <span key={m.id} className="chip-corrida">
+              {modalityKindEmoji(m.kind)} {modalityLabel(m)}
+            </span>
+          ))}
+        </div>
         <h1 className="my-2 -rotate-1 font-display text-3xl sm:text-4xl">
           {data.name}
         </h1>
@@ -107,18 +127,52 @@ export default function EventDetail() {
         </div>
 
         {!mine && (
-          <button
-            type="button"
-            onClick={handleSubscribe}
-            disabled={subscribing}
-            className="btn-corrida btn-corrida--agua"
-          >
-            {subscribing ? 'Entrando...' : 'Entrar na pista 🎉'}
-          </button>
+          <div className="max-w-sm">
+            {data.modalities.length > 1 && (
+              <>
+                <span className="mb-1.5 block text-xs font-semibold uppercase tracking-wider opacity-85">
+                  Sua modalidade
+                </span>
+                <div className="mb-3 flex flex-col gap-2">
+                  {data.modalities.map((m) => (
+                    <label
+                      key={m.id}
+                      className={`flex cursor-pointer items-center gap-2.5 rounded-2xl border-2 p-3 text-sm ${
+                        selectedModality === m.id
+                          ? 'border-amarelo bg-black/25'
+                          : 'border-white/25 hover:border-white/50'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="modality"
+                        className="accent-amarelo"
+                        checked={selectedModality === m.id}
+                        onChange={() => setChosenModality(m.id)}
+                      />
+                      <span>
+                        {modalityKindEmoji(m.kind)} {modalityLabel(m)}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </>
+            )}
+            <button
+              type="button"
+              onClick={() => handleSubscribe(selectedModality)}
+              disabled={subscribing}
+              className="btn-corrida btn-corrida--agua"
+            >
+              {subscribing ? 'Entrando...' : 'Entrar na pista 🎉'}
+            </button>
+          </div>
         )}
         {mine?.status === 'registered' && (
           <div className="rounded-2xl bg-black/25 p-4 text-sm text-white">
-            ✓ Você tá na pista! Quando terminar a corrida, envie sua foto em{' '}
+            ✓ Você tá na pista
+            {mine.modality ? ` na ${modalityLabel(mine.modality)}` : ''}! Quando
+            terminar a corrida, envie sua foto em{' '}
             <Link to="/medalhas" className="font-semibold text-amarelo">
               Minhas medalhas
             </Link>{' '}
@@ -127,8 +181,9 @@ export default function EventDetail() {
         )}
         {mine?.status === 'completed' && (
           <div className="rounded-2xl bg-black/25 p-4 text-sm text-white">
-            🏅 Você concluiu esta corrida! Sua medalha está no mural aqui
-            embaixo e em{' '}
+            🏅 Você concluiu esta corrida
+            {mine.modality ? ` (${modalityLabel(mine.modality)})` : ''}! Sua
+            medalha está no mural aqui embaixo e em{' '}
             <Link to="/medalhas" className="font-semibold text-amarelo">
               Minhas medalhas
             </Link>
@@ -157,7 +212,13 @@ export default function EventDetail() {
                 key={r.id}
                 name={firstName(r.userName)}
                 photo={r.proofPhoto}
-                caption={`concluiu em ${formatDate(r.completedAt)}`}
+                caption={
+                  r.modality
+                    ? `${modalityLabel(r.modality)} · ${formatDate(
+                        r.completedAt
+                      )}`
+                    : `concluiu em ${formatDate(r.completedAt)}`
+                }
               />
             ))}
           </div>

--- a/src/pages/EventList.tsx
+++ b/src/pages/EventList.tsx
@@ -3,7 +3,12 @@ import { Link, useNavigate } from 'react-router-dom';
 import { listEvents } from '../api/events';
 import { gqlErrorMessage } from '../api/graphql';
 import { useUser } from '../contexts/Auth';
-import { formatDate, formatKm, posterGradient } from '../utils';
+import {
+  formatDate,
+  modalityKindEmoji,
+  modalityLabel,
+  posterGradient,
+} from '../utils';
 
 export default function EventList() {
   const user = useUser();
@@ -48,8 +53,14 @@ export default function EventList() {
                 {event.name}
               </h3>
               <span className="text-sm opacity-90">
-                {formatKm(event.distanceKm)} · {formatDate(event.startDate)} a{' '}
-                {formatDate(event.endDate)}
+                {formatDate(event.startDate)} a {formatDate(event.endDate)}
+              </span>
+              <span className="flex flex-wrap gap-1.5">
+                {event.modalities.map((m) => (
+                  <span key={m.id} className="chip-corrida">
+                    {modalityKindEmoji(m.kind)} {modalityLabel(m)}
+                  </span>
+                ))}
               </span>
               <span className="mt-auto flex flex-wrap items-center gap-2">
                 <span className="chip-corrida">

--- a/src/pages/MyMedals.tsx
+++ b/src/pages/MyMedals.tsx
@@ -11,7 +11,7 @@ import { useUser } from '../contexts/Auth';
 import {
   firstName,
   formatDate,
-  formatKm,
+  modalityLabel,
   photoToDataUrl,
   throwConfetti,
 } from '../utils';
@@ -105,7 +105,7 @@ export default function MyMedals() {
                     </Link>
                   </h3>
                   <span className="text-sm text-papel-suave">
-                    {formatKm(reg.event.distanceKm)} ·{' '}
+                    {reg.modality ? `${modalityLabel(reg.modality)} · ` : ''}
                     {formatDate(reg.event.startDate)} a{' '}
                     {formatDate(reg.event.endDate)}
                   </span>

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,11 +6,20 @@ export interface SessionUser {
 
 export type RegistrationStatus = 'registered' | 'completed';
 
+/** Tipo da modalidade: caminhada ou corrida. Neutro no banco ('walk'/'run'). */
+export type ModalityKind = 'walk' | 'run';
+
+export interface Modality {
+  id: string;
+  kind: ModalityKind;
+  distanceKm: number;
+}
+
 export interface EventSummary {
   id: string;
   name: string;
   description: string;
-  distanceKm: number;
+  modalities: Modality[];
   startDate: string;
   endDate: string;
   registrationCount: number;
@@ -25,13 +34,14 @@ export interface EventRegistration {
   status: RegistrationStatus;
   completedAt: string | null;
   proofPhoto: string | null;
+  modality: Modality | null;
 }
 
 export interface EventDetail {
   id: string;
   name: string;
   description: string;
-  distanceKm: number;
+  modalities: Modality[];
   startDate: string;
   endDate: string;
   creatorName: string | null;
@@ -43,10 +53,10 @@ export interface MyRegistration {
   status: RegistrationStatus;
   completedAt: string | null;
   proofPhoto: string | null;
+  modality: Modality | null;
   event: {
     id: string;
     name: string;
-    distanceKm: number;
     startDate: string;
     endDate: string;
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import type { Modality, ModalityKind } from './types';
+
 export function formatDate(iso: string | null | undefined): string {
   if (!iso) return '';
   const [, month, day] = iso.slice(0, 10).split('-');
@@ -6,6 +8,28 @@ export function formatDate(iso: string | null | undefined): string {
 
 export function formatKm(km: number): string {
   return `${km.toLocaleString('pt-BR')} km`;
+}
+
+/** Rótulo humano do tipo de modalidade. */
+export function modalityKindLabel(kind: ModalityKind): string {
+  return kind === 'walk' ? 'Caminhada' : 'Corrida';
+}
+
+/** Emoji do tipo, para chips compactos. */
+export function modalityKindEmoji(kind: ModalityKind): string {
+  return kind === 'walk' ? '🚶' : '🏃';
+}
+
+/** Ex.: "Corrida 10 km". */
+export function modalityLabel(m: Modality): string {
+  return `${modalityKindLabel(m.kind)} ${formatKm(m.distanceKm)}`;
+}
+
+/** Ordena por distância, depois tipo — para exibição estável. */
+export function sortModalities(modalities: Modality[]): Modality[] {
+  return [...modalities].sort(
+    (a, b) => a.distanceKm - b.distanceKm || a.kind.localeCompare(b.kind)
+  );
 }
 
 export function firstName(name: string): string {


### PR DESCRIPTION
Uma corrida passa a ter várias modalidades (caminhada 3km, corrida 10km...)
na mesma prova. A distância deixa de morar no evento e vai para cada
modalidade; a inscrição escolhe uma.

Banco (hasura/schema.sql):
- nova tabela event_modalities (event_id, kind walk|run, distance_km)
- registrations.modality_id (anulável) + trigger que deriva event_id da
  modalidade, mantendo a unique (event_id, user_id) = uma pista por pessoa
- events.distance_km vira anulável/legado; backfill idempotente cria uma
  modalidade 'run' por evento existente e liga as inscrições a ela

Metadata (hasura/metadata.json):
- track event_modalities: relacionamentos + select para runner e insert
  restrito a corrida criada pela própria pessoa (event.created_by)
- registrations: relacionamento modality e insert por modality_id
- events: relacionamento modalities

Frontend:
- criar corrida: lista dinâmica de modalidades (tipo + distância)
- detalhe: chips das modalidades; ao entrar na pista escolhe a modalidade;
  mural de medalhas mostra a modalidade concluída
- lista e minhas medalhas exibem as modalidades

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M5itSb77KLqPA9RPCupDyu