### PR TITLE
Redesenho da lista, revisão do detalhe e navegação estilo app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { Route, Routes } from 'react-router-dom';
+import BottomNav from './components/BottomNav';
 import Header from './components/Header';
 import RequireAuth from './components/RequireAuth';
 import Login from './pages/Login';
@@ -46,6 +47,7 @@ export default function App() {
           }
         />
       </Routes>
+      <BottomNav />
     </div>
   );
 }

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,0 +1,100 @@
+import { NavLink } from 'react-router-dom';
+import { useAuth } from '../contexts/Auth';
+
+type IconProps = { className?: string };
+
+function IconCorridas({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      width="24"
+      height="24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 10.5 12 3l9 7.5" />
+      <path d="M5 9.8V20h14V9.8" />
+    </svg>
+  );
+}
+
+function IconCriar({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      width="24"
+      height="24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 8v8M8 12h8" />
+    </svg>
+  );
+}
+
+function IconMedalhas({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      width="24"
+      height="24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M8.5 9 6.5 3.5M15.5 9l2-5.5M10.5 3.5 12 6.5l1.5-3" />
+      <circle cx="12" cy="15" r="6" />
+    </svg>
+  );
+}
+
+const items = [
+  { to: '/', end: true, label: 'Corridas', Icon: IconCorridas },
+  { to: '/criar', end: false, label: 'Criar', Icon: IconCriar },
+  { to: '/medalhas', end: false, label: 'Medalhas', Icon: IconMedalhas },
+];
+
+export default function BottomNav() {
+  const { user } = useAuth();
+  if (!user) return null;
+
+  return (
+    <nav
+      aria-label="Navegação principal"
+      className="fixed inset-x-0 bottom-0 z-40 border-t border-white/10 bg-palco/95 pb-[env(safe-area-inset-bottom)] backdrop-blur"
+    >
+      <div className="mx-auto flex max-w-md items-stretch justify-around">
+        {items.map(({ to, end, label, Icon }) => (
+          <NavLink
+            key={to}
+            to={to}
+            end={end}
+            className={({ isActive }) =>
+              `flex flex-1 flex-col items-center gap-1 py-2 text-[0.66rem] font-semibold no-underline transition-colors ${
+                isActive ? 'text-agua' : 'text-papel-suave hover:text-papel'
+              }`
+            }
+          >
+            <Icon />
+            <span>{label}</span>
+          </NavLink>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,13 +1,6 @@
-import { Link, NavLink, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/Auth';
 import { firstName } from '../utils';
-
-const tabClass = ({ isActive }: { isActive: boolean }) =>
-  `rounded-full px-3.5 py-1.5 text-sm font-semibold no-underline ${
-    isActive
-      ? 'bg-agua text-agua-escuro'
-      : 'text-papel-suave hover:bg-palco-2 hover:text-papel'
-  }`;
 
 export default function Header() {
   const { user, signOut } = useAuth();
@@ -16,39 +9,26 @@ export default function Header() {
   if (!user) return null;
 
   return (
-    <nav className="mx-auto max-w-4xl px-5 py-3.5">
-      <div className="flex items-center gap-2.5">
-        <Link
-          to="/"
-          className="mr-auto inline-block -rotate-2 font-display text-2xl text-amarelo no-underline"
-        >
-          VirtuRace
-        </Link>
-        <span className="hidden text-sm text-papel-suave sm:inline">
-          Oi, {firstName(user.name)}!
-        </span>
-        <button
-          type="button"
-          onClick={() => {
-            signOut();
-            navigate('/login');
-          }}
-          className="shrink-0 rounded-full border border-roxo-claro px-3.5 py-1.5 text-sm font-semibold text-papel-suave hover:border-agua hover:text-agua"
-        >
-          Sair
-        </button>
-      </div>
-      <div className="mt-2.5 flex flex-wrap gap-1.5">
-        <NavLink to="/" end className={tabClass}>
-          Corridas
-        </NavLink>
-        <NavLink to="/criar" className={tabClass}>
-          Criar corrida
-        </NavLink>
-        <NavLink to="/medalhas" className={tabClass}>
-          Minhas medalhas
-        </NavLink>
-      </div>
+    <nav className="mx-auto flex max-w-4xl items-center gap-2.5 px-5 py-3.5">
+      <Link
+        to="/"
+        className="mr-auto inline-block -rotate-2 font-display text-2xl text-amarelo no-underline"
+      >
+        VirtuRace
+      </Link>
+      <span className="hidden text-sm text-papel-suave sm:inline">
+        Oi, {firstName(user.name)}!
+      </span>
+      <button
+        type="button"
+        onClick={() => {
+          signOut();
+          navigate('/login');
+        }}
+        className="shrink-0 rounded-full border border-roxo-claro px-3.5 py-1.5 text-sm font-semibold text-papel-suave hover:border-agua hover:text-agua"
+      >
+        Sair
+      </button>
     </nav>
   );
 }

--- a/src/pages/EventCreate.tsx
+++ b/src/pages/EventCreate.tsx
@@ -83,7 +83,7 @@ export default function EventCreate() {
   }
 
   return (
-    <main className="mx-auto max-w-4xl px-5 pb-20 pt-4">
+    <main className="mx-auto max-w-4xl px-5 pb-24 pt-4">
       <h1 className="titulo-corrida">
         Monta a <span className="text-laranja">tua corrida</span>
       </h1>

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -9,6 +9,7 @@ import { useUser } from '../contexts/Auth';
 import {
   firstName,
   formatDate,
+  formatRangeShort,
   modalityKindEmoji,
   modalityLabel,
   posterGradient,
@@ -99,17 +100,17 @@ export default function EventDetail() {
         </h1>
         <p className="mb-4 max-w-xl opacity-95">{data.description}</p>
 
-        <div className="mb-5 flex flex-wrap gap-7">
+        <div className="mb-5 flex flex-wrap gap-x-6 gap-y-3">
           <div>
-            <b className="block font-display text-2xl tabular-nums">
-              {formatDate(data.startDate)}–{formatDate(data.endDate)}
+            <b className="block font-display text-xl tabular-nums">
+              {formatRangeShort(data.startDate, data.endDate)}
             </b>
             <span className="text-xs uppercase tracking-wider opacity-85">
               período
             </span>
           </div>
           <div>
-            <b className="block font-display text-2xl tabular-nums">
+            <b className="block font-display text-xl tabular-nums">
               {data.registrations.length}
             </b>
             <span className="text-xs uppercase tracking-wider opacity-85">
@@ -117,7 +118,7 @@ export default function EventDetail() {
             </span>
           </div>
           <div>
-            <b className="block font-display text-2xl tabular-nums">
+            <b className="block font-display text-xl tabular-nums">
               {completed.length}
             </b>
             <span className="text-xs uppercase tracking-wider opacity-85">

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -79,7 +79,7 @@ export default function EventDetail() {
   const selectedModality = chosenModality || soloModality;
 
   return (
-    <main className="mx-auto max-w-4xl px-5 pb-20 pt-4">
+    <main className="mx-auto max-w-4xl px-5 pb-24 pt-4">
       <Link
         to="/"
         className="text-sm font-semibold text-agua no-underline hover:underline"

--- a/src/pages/EventList.tsx
+++ b/src/pages/EventList.tsx
@@ -14,7 +14,7 @@ export default function EventList() {
   });
 
   return (
-    <main className="mx-auto max-w-4xl px-5 pb-20 pt-4">
+    <main className="mx-auto max-w-4xl px-5 pb-24 pt-4">
       <h1 className="titulo-corrida">
         Corridas na <span className="text-laranja">pista</span>
       </h1>

--- a/src/pages/EventList.tsx
+++ b/src/pages/EventList.tsx
@@ -3,12 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { listEvents } from '../api/events';
 import { gqlErrorMessage } from '../api/graphql';
 import { useUser } from '../contexts/Auth';
-import {
-  formatDate,
-  modalityKindEmoji,
-  modalityLabel,
-  posterGradient,
-} from '../utils';
+import { dateRangeParts, groupModalities, posterGradient } from '../utils';
 
 export default function EventList() {
   const user = useUser();
@@ -42,42 +37,79 @@ export default function EventList() {
 
       {data && data.length > 0 && (
         <div className="grid gap-4 sm:grid-cols-2">
-          {data.map((event, i) => (
-            <button
-              key={event.id}
-              type="button"
-              onClick={() => navigate(`/corrida/${event.id}`)}
-              className={`${posterGradient(i)} flex min-h-[150px] flex-col gap-2 rounded-[20px] p-5 text-left transition-transform hover:-rotate-1 hover:scale-[1.015] motion-reduce:transform-none`}
-            >
-              <h3 className="font-display text-xl leading-tight">
-                {event.name}
-              </h3>
-              <span className="text-sm opacity-90">
-                {formatDate(event.startDate)} a {formatDate(event.endDate)}
-              </span>
-              <span className="flex flex-wrap gap-1.5">
-                {event.modalities.map((m) => (
-                  <span key={m.id} className="chip-corrida">
-                    {modalityKindEmoji(m.kind)} {modalityLabel(m)}
+          {data.map((event, i) => {
+            const dt = dateRangeParts(event.startDate, event.endDate);
+            const groups = groupModalities(event.modalities);
+            return (
+              <button
+                key={event.id}
+                type="button"
+                onClick={() => navigate(`/corrida/${event.id}`)}
+                className={`${posterGradient(i)} flex min-h-[190px] flex-col overflow-hidden rounded-[22px] text-left transition-transform hover:-rotate-1 hover:scale-[1.015] motion-reduce:transform-none`}
+              >
+                <div className="flex flex-1 gap-3.5 p-4">
+                  <div className="flex flex-none flex-col items-center justify-center rounded-2xl bg-black/25 px-3 py-2.5 text-papel">
+                    <span className="font-display text-2xl leading-none">
+                      {dt.startDay}
+                    </span>
+                    {dt.sameMonth ? (
+                      <>
+                        <span className="my-0.5 text-[0.6rem] opacity-70">↓</span>
+                        <span className="font-display text-lg leading-none">
+                          {dt.endDay}
+                        </span>
+                        <span className="mt-1 text-[0.62rem] font-bold uppercase tracking-wider opacity-80">
+                          {dt.startMon}
+                        </span>
+                      </>
+                    ) : (
+                      <>
+                        <span className="text-[0.56rem] font-bold uppercase tracking-wider opacity-80">
+                          {dt.startMon}
+                        </span>
+                        <span className="my-0.5 text-[0.6rem] opacity-70">↓</span>
+                        <span className="font-display text-lg leading-none">
+                          {dt.endDay}
+                        </span>
+                        <span className="mt-0.5 text-[0.56rem] font-bold uppercase tracking-wider opacity-80">
+                          {dt.endMon}
+                        </span>
+                      </>
+                    )}
+                  </div>
+
+                  <div className="flex min-w-0 flex-col gap-2">
+                    <h3 className="-rotate-1 font-display text-2xl leading-none">
+                      {event.name}
+                    </h3>
+                    <span className="flex flex-wrap gap-1.5">
+                      {groups.map((g) => (
+                        <span
+                          key={g.kind}
+                          className="rounded-full bg-white/20 px-2.5 py-1 text-sm font-semibold"
+                        >
+                          {g.emoji} {g.label}
+                        </span>
+                      ))}
+                    </span>
+                  </div>
+                </div>
+
+                <span className="mt-auto flex items-center justify-between gap-2 bg-black/25 px-4 py-2.5 text-sm text-papel">
+                  <span className="flex items-center gap-2 font-semibold">
+                    <span className="inline-block h-1.5 w-1.5 rounded-full bg-current opacity-70" />
+                    {event.registrationCount} na pista
+                    {event.completedCount > 0 && (
+                      <span className="opacity-90">· 🏅 {event.completedCount}</span>
+                    )}
                   </span>
-                ))}
-              </span>
-              <span className="mt-auto flex flex-wrap items-center gap-2">
-                <span className="chip-corrida">
-                  {event.registrationCount} na pista
+                  <span className="font-display">
+                    {event.amRegistered ? 'você tá dentro ✓' : 'entrar →'}
+                  </span>
                 </span>
-                {event.completedCount > 0 && (
-                  <span className="chip-corrida chip-corrida--sol">
-                    🏅 {event.completedCount} medalha
-                    {event.completedCount > 1 ? 's' : ''}
-                  </span>
-                )}
-                {event.amRegistered && (
-                  <span className="chip-corrida">você tá dentro ✓</span>
-                )}
-              </span>
-            </button>
-          ))}
+              </button>
+            );
+          })}
         </div>
       )}
     </main>

--- a/src/pages/MyMedals.tsx
+++ b/src/pages/MyMedals.tsx
@@ -59,7 +59,7 @@ export default function MyMedals() {
   }
 
   return (
-    <main className="mx-auto max-w-4xl px-5 pb-20 pt-4">
+    <main className="mx-auto max-w-4xl px-5 pb-24 pt-4">
       <h1 className="titulo-corrida">
         Minhas <span className="text-laranja">medalhas</span>
       </h1>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,6 +32,59 @@ export function sortModalities(modalities: Modality[]): Modality[] {
   );
 }
 
+/** Junta distâncias num rótulo curto: [3,5] → "3 e 5 km". */
+export function joinKm(distances: number[]): string {
+  const nums = distances.map((d) => d.toLocaleString('pt-BR'));
+  if (nums.length === 0) return '';
+  if (nums.length === 1) return `${nums[0]} km`;
+  const last = nums[nums.length - 1];
+  return `${nums.slice(0, -1).join(', ')} e ${last} km`;
+}
+
+/**
+ * Agrupa as modalidades por tipo para chips compactos — corrida antes de
+ * caminhada, distâncias em ordem. Ex.: [{run,3},{run,5},{walk,5}] vira
+ * [{run, "3 e 5 km"}, {walk, "5 km"}].
+ */
+export function groupModalities(
+  modalities: Modality[]
+): { kind: ModalityKind; emoji: string; label: string }[] {
+  const byKind = new Map<ModalityKind, number[]>();
+  for (const m of sortModalities(modalities)) {
+    const arr = byKind.get(m.kind) ?? [];
+    arr.push(m.distanceKm);
+    byKind.set(m.kind, arr);
+  }
+  const order: ModalityKind[] = ['run', 'walk'];
+  return order
+    .filter((kind) => byKind.has(kind))
+    .map((kind) => ({
+      kind,
+      emoji: modalityKindEmoji(kind),
+      label: joinKm(byKind.get(kind) as number[]),
+    }));
+}
+
+const MONTHS_PT = [
+  'jan', 'fev', 'mar', 'abr', 'mai', 'jun',
+  'jul', 'ago', 'set', 'out', 'nov', 'dez',
+];
+
+/** Peças do bloco de data do card: dia inicial/final e mês(es) abreviados. */
+export function dateRangeParts(startIso: string, endIso: string) {
+  const s = startIso.slice(0, 10).split('-');
+  const e = endIso.slice(0, 10).split('-');
+  const startMon = MONTHS_PT[Number(s[1]) - 1] ?? '';
+  const endMon = MONTHS_PT[Number(e[1]) - 1] ?? '';
+  return {
+    startDay: s[2] ?? '',
+    endDay: e[2] ?? '',
+    startMon,
+    endMon,
+    sameMonth: startMon === endMon,
+  };
+}
+
 export function firstName(name: string): string {
   return name.trim().split(/\s+/)[0] ?? name;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,6 +70,14 @@ const MONTHS_PT = [
   'jul', 'ago', 'set', 'out', 'nov', 'dez',
 ];
 
+/** Intervalo curto para o pôster: "22–31 ago" ou "28 ago–03 set". */
+export function formatRangeShort(startIso: string, endIso: string): string {
+  const p = dateRangeParts(startIso, endIso);
+  return p.sameMonth
+    ? `${p.startDay}–${p.endDay} ${p.startMon}`
+    : `${p.startDay} ${p.startMon}–${p.endDay} ${p.endMon}`;
+}
+
 /** Peças do bloco de data do card: dia inicial/final e mês(es) abreviados. */
 export function dateRangeParts(startIso: string, endIso: string) {
   const s = startIso.slice(0, 10).split('-');

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,10 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  // Os gradientes dos cartazes são escolhidos em runtime (`g${i}` em
+  // posterGradient), então nunca aparecem como texto literal — sem isto o
+  // Tailwind purga .g0–.g3 e os cards ficam sem fundo.
+  safelist: ['g0', 'g1', 'g2', 'g3'],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## O que muda

Três frentes de UI, mais a correção de um bug de fundo que deixava os cartazes sem gradiente.

**Card da lista (EventList)** — estilo "cartaz": gradiente cheio, bloco de data empilhado à esquerda, modalidades agrupadas por tipo em chips compactos ("🏃 3 e 5 km") e faixa de rodapé escura com "na pista", medalhas e o convite (entrar → / você tá dentro ✓).

**Bug do gradiente** — as classes `g0–g3` eram escolhidas em runtime (`posterGradient`) e nunca apareciam como texto literal, então o Tailwind as purgava; os cartazes da lista **e** da tela de detalhe ficavam sem fundo. Adiciona `safelist` no `tailwind.config.js`.

**Tela de detalhe (EventDetail)** — período em formato compacto ("22–31 ago") e stats menores, para período / na pista / medalhas caberem numa linha só (antes "medalhas" caía órfã na segunda linha).

**Navegação estilo app** — novo `BottomNav`: barra fixa no rodapé com ícone + texto (Corridas / Criar / Medalhas), item ativo em água. O header do topo fica só com a marca e o Sair, o que também elimina a quebra das abas no mobile. Páginas sobem para `pb-24` para não ficarem sob a barra.

Novos helpers em `utils.ts`: `groupModalities`, `joinKm`, `dateRangeParts`, `formatRangeShort`.

## Arquivos

- `tailwind.config.js`, `src/utils.ts`
- `src/App.tsx`, `src/components/BottomNav.tsx` (novo), `src/components/Header.tsx`
- `src/pages/EventList.tsx`, `EventDetail.tsx`, `EventCreate.tsx`, `MyMedals.tsx`

## Como verificar

- `npm run build` e `npm run lint` passam.
- `grep -c linear-gradient` no CSS compilado agora encontra os gradientes (antes: 0).
- Screenshots headless em 412px e 900px conferidos: lista, detalhe (não inscrito com várias modalidades e inscrito) e barra de navegação.
- Sem mudança de banco/metadata — só front; deploy da Vercel resolve no merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqYMC2cebnBcFSzVGJyJqn)_