### PR TITLE
Minhas pistas: corridas criadas + inscritas, e ajustes de texto no cadastro

### DIFF
--- a/src/pages/MyTracks.tsx
+++ b/src/pages/MyTracks.tsx
@@ -1,6 +1,6 @@
 import { useState, type ChangeEvent } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { listMyCreatedEvents } from '../api/events';
 import { gqlErrorMessage } from '../api/graphql';
 import {
@@ -37,6 +37,7 @@ function todayIso(): string {
 
 export default function MyTracks() {
   const user = useUser();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [uploadingId, setUploadingId] = useState<string | null>(null);
   const [error, setError] = useState('');
@@ -134,7 +135,8 @@ export default function MyTracks() {
     return (
       <div
         key={t.eventId}
-        className="flex flex-wrap items-center gap-4 rounded-3xl bg-palco p-5"
+        onClick={() => navigate(`/corrida/${t.eventId}`)}
+        className="flex cursor-pointer flex-wrap items-center gap-4 rounded-3xl bg-palco p-5 transition-colors hover:bg-palco-2"
       >
         <div className="min-w-[190px] flex-1">
           <h3 className="font-display text-lg">
@@ -188,8 +190,11 @@ export default function MyTracks() {
             caption={`em ${formatDate(reg.completedAt)}`}
           />
         ) : reg ? (
-          <label className="btn-corrida cursor-pointer text-base">
-            {uploadingId === reg.id ? 'Cunhando...' : '📷 Cunhar minha medalha'}
+          <label
+            className="btn-corrida cursor-pointer text-base"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {uploadingId === reg.id ? 'Enviando...' : '📷 Finalizei'}
             <input
               type="file"
               accept="image/*"


### PR DESCRIPTION
## O que muda

- **Aba "Medalhas" → "Minhas pistas"** (rota `/minhas-pistas`, ícone de bandeira de largada). A página lista as corridas do usuário logado, próximas e passadas, reunindo numa pista por corrida:
  - as que ele **entrou** (mantém a cunhagem de medalha e a medalha pronta nas concluídas);
  - as que ele **criou** (badge "🎪 Você organiza" + contagem "X na pista · Y medalhas cunhadas"), mesmo sem estar inscrito;
  - se criou *e* entrou, aparece uma vez só com os dois selos.
  - Separadas em "Próximas e em andamento" e "Já rolaram".
- **Card clicável** leva ao detalhe da corrida (`/corrida/:id`); o botão de foto não navega junto.
- **Botão "Cunhar minha medalha" → "Finalizei"** (envio: "Enviando...").
- **Cadastro de corrida:** botão "Soltar o cartaz" → "Abrir a pista"; placeholder do convite → "Detalhe a corrida e faça a chamada pra galera."; removido o texto auxiliar do bloco Modalidades.

## Arquivos

- `src/pages/MyMedals.tsx` → `src/pages/MyTracks.tsx` (renomeada/reescrita)
- `src/api/events.ts` — nova consulta `listMyCreatedEvents`
- `src/pages/EventCreate.tsx`, `src/pages/EventDetail.tsx`, `src/components/BottomNav.tsx`, `src/App.tsx`, `README.md`

## Banco / metadata

Sem mudança. `events.created_by` já é selecionável pelo papel `runner` com filtro aberto — a nova consulta roda sem tocar schema nem permissões. Nada a rodar no console; é só push/deploy.

## Como verificar

- Aba inferior "Minhas pistas": aparecem tanto corridas inscritas quanto criadas; passadas e futuras nas seções certas.
- Tocar no card abre o detalhe; tocar em "Finalizei" abre a câmera sem navegar.
- Cadastro: textos novos no botão e no convite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyvW4fkCzTbtrxFfkKw6KH)_