### PR TITLE
Login: logo 20% menor e mais colado no topo

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -35,12 +35,12 @@ export default function Login() {
   }
 
   return (
-    <main className="mx-auto max-w-4xl px-5 pb-20 pt-14">
+    <main className="mx-auto max-w-4xl px-5 pb-20 pt-8">
       <div className="mb-7 text-center">
         <img
           src={logoAmarelo}
           alt="VirtuRace"
-          className="mx-auto mb-2 h-auto w-full max-w-[280px]"
+          className="mx-auto mb-2 h-auto w-full max-w-[224px]"
         />
         <h1 className="titulo-corrida mt-1 text-center">
           Bora correr <span className="text-laranja">por aí?</span>


### PR DESCRIPTION
Ajuste visual do logo na home deslogada, seguindo o #27 (já mergeado).

## O que muda
- Logo amarelo reduzido: `max-w-[280px]` → `max-w-[224px]` (−20%).
- Menos espaço até o topo: padding superior do `main` de `pt-14` → `pt-8`.

## Arquivos
- `src/pages/Login.tsx`

## Como verificar
Abrir a home deslogada (`/login`): o logo aparece menor e mais próximo do topo, acima de "Bora correr por aí?".

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019KYMt2tCXFjPSZcKwpU1N1)_