### PR TITLE
Coleta a cidade da corrida no momento da inscrição

### DIFF
--- a/hasura/metadata.json
+++ b/hasura/metadata.json
@@ -162,7 +162,7 @@
                 "permission": {
                   "check": {},
                   "set": { "user_id": "x-hasura-user-id" },
-                  "columns": ["event_id", "modality_id"]
+                  "columns": ["event_id", "modality_id", "city"]
                 }
               }
             ],
@@ -177,7 +177,8 @@
                     "status",
                     "registered_at",
                     "completed_at",
-                    "proof_photo"
+                    "proof_photo",
+                    "city"
                   ],
                   "filter": {},
                   "allow_aggregations": true

--- a/hasura/schema.sql
+++ b/hasura/schema.sql
@@ -99,6 +99,13 @@ create trigger registrations_set_event_id
   before insert on public.registrations
   for each row execute function public.set_registration_event_id();
 
+-- Cidade onde a pessoa vai correr, informada no momento da inscrição. Guardada
+-- para consulta futura (o uso ainda será definido). Anulável de propósito:
+-- linhas antigas e a janela de deploy entre metadata e código não têm cidade;
+-- o app novo passa a exigir no formulário de "entrar na pista".
+alter table public.registrations
+  add column if not exists city text;
+
 create index if not exists registrations_event_idx on public.registrations (event_id);
 create index if not exists registrations_user_idx on public.registrations (user_id);
 create index if not exists registrations_modality_idx on public.registrations (modality_id);

--- a/src/api/registrations.ts
+++ b/src/api/registrations.ts
@@ -73,15 +73,18 @@ export async function listMyRegistrations(
 }
 
 const REGISTER = `
-  mutation Register($modalityId: uuid!) {
-    insert_registrations_one(object: { modality_id: $modalityId }) {
+  mutation Register($modalityId: uuid!, $city: String!) {
+    insert_registrations_one(object: { modality_id: $modalityId, city: $city }) {
       id
     }
   }
 `;
 
-export async function registerForModality(modalityId: string): Promise<void> {
-  await graphqlClient.request(REGISTER, { modalityId });
+export async function registerForModality(
+  modalityId: string,
+  city: string
+): Promise<void> {
+  await graphqlClient.request(REGISTER, { modalityId, city });
 }
 
 const COMPLETE = `

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -22,6 +22,7 @@ export default function EventDetail() {
   const [subscribing, setSubscribing] = useState(false);
   const [actionError, setActionError] = useState('');
   const [chosenModality, setChosenModality] = useState('');
+  const [city, setCity] = useState('');
   const [shareMsg, setShareMsg] = useState('');
 
   const { data, error, isPending } = useQuery({
@@ -38,15 +39,20 @@ export default function EventDetail() {
     };
   }, [data?.name]);
 
-  async function handleSubscribe(modalityId: string) {
+  async function handleSubscribe(modalityId: string, cityValue: string) {
     if (!modalityId) {
       setActionError('Escolha uma modalidade para entrar na pista.');
+      return;
+    }
+    const trimmedCity = cityValue.trim();
+    if (!trimmedCity) {
+      setActionError('Diga em qual cidade você vai correr.');
       return;
     }
     setActionError('');
     setSubscribing(true);
     try {
-      await registerForModality(modalityId);
+      await registerForModality(modalityId, trimmedCity);
       await queryClient.invalidateQueries({ queryKey: ['event', id] });
       queryClient.invalidateQueries({ queryKey: ['events'] });
       queryClient.invalidateQueries({ queryKey: ['myRegistrations'] });
@@ -230,9 +236,24 @@ export default function EventDetail() {
                 </div>
               </>
             )}
+            <label
+              htmlFor="city"
+              className="mb-1.5 block text-xs font-semibold uppercase tracking-wider opacity-85"
+            >
+              Onde você vai correr
+            </label>
+            <input
+              id="city"
+              type="text"
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+              placeholder="Sua cidade"
+              autoComplete="address-level2"
+              className="mb-3 w-full rounded-2xl border-2 border-white/25 bg-black/25 p-3 text-sm text-white outline-none placeholder:text-white/55 focus:border-amarelo"
+            />
             <button
               type="button"
-              onClick={() => handleSubscribe(selectedModality)}
+              onClick={() => handleSubscribe(selectedModality, city)}
               disabled={subscribing}
               className="btn-corrida btn-corrida--agua"
             >


### PR DESCRIPTION
- registrations.city (text, anulável): cidade informada ao entrar na pista,
  guardada para consulta futura (uso ainda a definir).
- schema.sql: add column if not exists (idempotente).
- metadata.json: city nas colunas de insert e select de registrations (runner).
- Inscrição passa a exigir a cidade no formulário; mutation envia $city.

Como verificar: abrir uma corrida, tentar entrar sem cidade (barra com aviso),
preencher e entrar; conferir registrations.city gravado.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V2X1LfdggvtCpzuzNy2gGA