### PR TITLE
Organizadora edita a corrida (detalhe e listagem)

### DIFF
--- a/hasura/README.md
+++ b/hasura/README.md
@@ -17,10 +17,13 @@ O passo a passo completo (com a ordem certa e as env vars) está em
 - Papel único `runner` (o usuário logado):
   - `users`: lê só `id` e `name` de qualquer pessoa (para o mural). E-mail e
     hash de senha nunca saem pelo GraphQL — só as funções de auth (admin) os tocam.
-  - `events`: lê tudo; cria com `created_by` travado no próprio usuário.
-  - `event_modalities`: lê tudo; só insere modalidade em corrida que a própria
-    pessoa criou (`event.created_by`). Uma corrida pode ter várias (caminhada
-    3km, corrida 10km...) — a distância mora aqui, não mais no evento.
+  - `events`: lê tudo; cria com `created_by` travado no próprio usuário; edita
+    (nome, convite, período) só a corrida que criou (`created_by = usuário`).
+  - `event_modalities`: lê tudo; só insere, edita ou remove modalidade em
+    corrida que a própria pessoa criou (`event.created_by`). Uma corrida pode
+    ter várias (caminhada 3km, corrida 10km...) — a distância mora aqui, não
+    mais no evento. (A UI evita remover modalidade com inscritos, para não
+    órfã as medalhas; o banco faria `set null` no `modality_id`.)
   - `registrations`: lê tudo (mural público entre logados); inscreve-se apenas
     a si mesmo (`user_id` vem da sessão) escolhendo uma `modality_id` — o
     `event_id` é preenchido por trigger a partir da modalidade, então a unique

--- a/hasura/metadata.json
+++ b/hasura/metadata.json
@@ -98,6 +98,16 @@
                   "filter": {}
                 }
               }
+            ],
+            "update_permissions": [
+              {
+                "role": "runner",
+                "permission": {
+                  "columns": ["name", "description", "start_date", "end_date"],
+                  "filter": { "created_by": { "_eq": "X-Hasura-User-Id" } },
+                  "check": {}
+                }
+              }
             ]
           },
           {
@@ -136,6 +146,28 @@
                 "permission": {
                   "columns": ["id", "event_id", "kind", "distance_km"],
                   "filter": {}
+                }
+              }
+            ],
+            "update_permissions": [
+              {
+                "role": "runner",
+                "permission": {
+                  "columns": ["kind", "distance_km"],
+                  "filter": {
+                    "event": { "created_by": { "_eq": "X-Hasura-User-Id" } }
+                  },
+                  "check": {}
+                }
+              }
+            ],
+            "delete_permissions": [
+              {
+                "role": "runner",
+                "permission": {
+                  "filter": {
+                    "event": { "created_by": { "_eq": "X-Hasura-User-Id" } }
+                  }
                 }
               }
             ]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Login from './pages/Login';
 import EventList from './pages/EventList';
 import EventCreate from './pages/EventCreate';
 import EventDetail from './pages/EventDetail';
+import EventEdit from './pages/EventEdit';
 import MyTracks from './pages/MyTracks';
 
 export default function App() {
@@ -35,6 +36,14 @@ export default function App() {
           element={
             <RequireAuth>
               <EventDetail />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/corrida/:id/editar"
+          element={
+            <RequireAuth>
+              <EventEdit />
             </RequireAuth>
           }
         />

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -24,6 +24,7 @@ const EVENTS_QUERY = `
       description
       start_date
       end_date
+      created_by
       modalities {
         id
         kind
@@ -43,6 +44,7 @@ interface EventsRow {
   description: string;
   start_date: string;
   end_date: string;
+  created_by: string;
   modalities: ModalityRow[];
   registrations: Array<{ user_id: string; status: string }>;
 }
@@ -62,6 +64,7 @@ export async function listEvents(myUserId: string): Promise<EventSummary[]> {
     completedCount: row.registrations.filter((r) => r.status === 'completed')
       .length,
     amRegistered: row.registrations.some((r) => r.user_id === myUserId),
+    creatorId: row.created_by,
   }));
 }
 
@@ -73,6 +76,7 @@ const EVENT_QUERY = `
       description
       start_date
       end_date
+      created_by
       creator {
         name
       }
@@ -101,6 +105,7 @@ const EVENT_QUERY = `
 `;
 
 interface EventRow extends Omit<EventsRow, 'registrations'> {
+  created_by: string;
   creator: { name: string } | null;
   registrations: Array<{
     id: string;
@@ -127,6 +132,7 @@ export async function getEvent(id: string): Promise<EventDetail | null> {
     modalities: sortModalities(row.modalities.map(toModality)),
     startDate: row.start_date,
     endDate: row.end_date,
+    creatorId: row.created_by,
     creatorName: row.creator?.name ?? null,
     registrations: row.registrations.map((r) => ({
       id: r.id,
@@ -239,4 +245,77 @@ export async function createEvent(input: {
     })),
   });
   return data.insert_events_one.id;
+}
+
+// Edição pela organizadora. Uma única mutation transacional no Hasura:
+// atualiza os campos do evento, atualiza as modalidades que ficaram, insere as
+// novas e apaga as removidas. As permissões (evento e modalidade travados em
+// `created_by = usuário`) barram quem não é dono no servidor.
+const UPDATE_EVENT = `
+  mutation UpdateEvent(
+    $id: uuid!
+    $name: String!
+    $description: String!
+    $startDate: date!
+    $endDate: date!
+    $newModalities: [event_modalities_insert_input!]!
+    $removedIds: [uuid!]!
+    $updates: [event_modalities_updates!]!
+  ) {
+    update_events_by_pk(
+      pk_columns: { id: $id }
+      _set: {
+        name: $name
+        description: $description
+        start_date: $startDate
+        end_date: $endDate
+      }
+    ) {
+      id
+    }
+    delete_event_modalities(where: { id: { _in: $removedIds } }) {
+      affected_rows
+    }
+    insert_event_modalities(objects: $newModalities) {
+      affected_rows
+    }
+    update_event_modalities_many(updates: $updates) {
+      affected_rows
+    }
+  }
+`;
+
+export interface ModalityUpdate {
+  id: string;
+  kind: ModalityKind;
+  distanceKm: number;
+}
+
+export async function updateEvent(input: {
+  id: string;
+  name: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+  newModalities: ModalityInput[];
+  updatedModalities: ModalityUpdate[];
+  removedModalityIds: string[];
+}): Promise<void> {
+  await graphqlClient.request(UPDATE_EVENT, {
+    id: input.id,
+    name: input.name,
+    description: input.description,
+    startDate: input.startDate,
+    endDate: input.endDate,
+    newModalities: input.newModalities.map((m) => ({
+      event_id: input.id,
+      kind: m.kind,
+      distance_km: m.distanceKm,
+    })),
+    removedIds: input.removedModalityIds,
+    updates: input.updatedModalities.map((m) => ({
+      where: { id: { _eq: m.id } },
+      _set: { kind: m.kind, distance_km: m.distanceKm },
+    })),
+  });
 }

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -176,29 +176,39 @@ export default function EventDetail() {
         </div>
 
         <div className="mb-5">
-          <button
-            type="button"
-            onClick={handleShare}
-            className="inline-flex items-center gap-2 rounded-full bg-black/25 px-4 py-2 text-sm font-semibold text-white transition hover:bg-black/40"
-          >
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="h-4 w-4"
-              aria-hidden="true"
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={handleShare}
+              className="inline-flex items-center gap-2 rounded-full bg-black/25 px-4 py-2 text-sm font-semibold text-white transition hover:bg-black/40"
             >
-              <circle cx="18" cy="5" r="3" />
-              <circle cx="6" cy="12" r="3" />
-              <circle cx="18" cy="19" r="3" />
-              <line x1="8.6" y1="13.5" x2="15.4" y2="17.5" />
-              <line x1="15.4" y1="6.5" x2="8.6" y2="10.5" />
-            </svg>
-            Compartilhar
-          </button>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-4 w-4"
+                aria-hidden="true"
+              >
+                <circle cx="18" cy="5" r="3" />
+                <circle cx="6" cy="12" r="3" />
+                <circle cx="18" cy="19" r="3" />
+                <line x1="8.6" y1="13.5" x2="15.4" y2="17.5" />
+                <line x1="15.4" y1="6.5" x2="8.6" y2="10.5" />
+              </svg>
+              Compartilhar
+            </button>
+            {data.creatorId === user.id && (
+              <Link
+                to={`/corrida/${data.id}/editar`}
+                className="inline-flex items-center gap-2 rounded-full bg-black/25 px-4 py-2 text-sm font-semibold text-white no-underline transition hover:bg-black/40"
+              >
+                ✏️ Editar corrida
+              </Link>
+            )}
+          </div>
           {shareMsg && (
             <p className="mt-2 break-all text-xs text-amarelo">{shareMsg}</p>
           )}

--- a/src/pages/EventEdit.tsx
+++ b/src/pages/EventEdit.tsx
@@ -1,0 +1,340 @@
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import {
+  getEvent,
+  updateEvent,
+  type ModalityInput,
+  type ModalityUpdate,
+} from '../api/events';
+import { gqlErrorMessage } from '../api/graphql';
+import { useUser } from '../contexts/Auth';
+import type { ModalityKind } from '../types';
+
+interface ModalityDraft {
+  key: number;
+  // id preenchido -> modalidade que já existe no banco; ausente -> nova.
+  id?: string;
+  kind: ModalityKind;
+  distanceKm: string;
+  // Tem gente inscrita nesta modalidade? Então não deixa remover (órfã a medalha).
+  inUse: boolean;
+}
+
+let draftKey = 0;
+
+export default function EventEdit() {
+  const { id = '' } = useParams<{ id: string }>();
+  const user = useUser();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { data, error, isPending } = useQuery({
+    queryKey: ['event', id],
+    queryFn: () => getEvent(id),
+  });
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [modalities, setModalities] = useState<ModalityDraft[]>([]);
+  const [formError, setFormError] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [ready, setReady] = useState(false);
+
+  // IDs de modalidade que têm inscrição — não podem ser removidas.
+  const inUseIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of data?.registrations ?? []) {
+      if (r.modality) set.add(r.modality.id);
+    }
+    return set;
+  }, [data]);
+
+  // Preenche o formulário uma vez, quando a corrida chega.
+  useEffect(() => {
+    if (!data || ready) return;
+    setName(data.name);
+    setDescription(data.description);
+    setStartDate(data.startDate.slice(0, 10));
+    setEndDate(data.endDate.slice(0, 10));
+    setModalities(
+      data.modalities.map((m) => ({
+        key: draftKey++,
+        id: m.id,
+        kind: m.kind,
+        distanceKm: String(m.distanceKm),
+        inUse: inUseIds.has(m.id),
+      }))
+    );
+    setReady(true);
+  }, [data, ready, inUseIds]);
+
+  function updateModality(key: number, patch: Partial<ModalityDraft>) {
+    setModalities((rows) =>
+      rows.map((r) => (r.key === key ? { ...r, ...patch } : r))
+    );
+  }
+
+  function addModality() {
+    setModalities((rows) => [
+      ...rows,
+      { key: draftKey++, kind: 'run', distanceKm: '', inUse: false },
+    ]);
+  }
+
+  function removeModality(key: number) {
+    setModalities((rows) => rows.filter((r) => r.key !== key));
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!data) return;
+    setFormError('');
+
+    if (endDate < startDate) {
+      setFormError('A data final precisa ser depois do começo.');
+      return;
+    }
+
+    for (const m of modalities) {
+      const km = Number(m.distanceKm);
+      if (!Number.isFinite(km) || km <= 0) {
+        setFormError('Cada modalidade precisa de uma distância maior que zero.');
+        return;
+      }
+    }
+    if (modalities.length === 0) {
+      setFormError('Deixe pelo menos uma modalidade.');
+      return;
+    }
+
+    const newModalities: ModalityInput[] = [];
+    const updatedModalities: ModalityUpdate[] = [];
+    for (const m of modalities) {
+      const distanceKm = Number(m.distanceKm);
+      if (m.id) updatedModalities.push({ id: m.id, kind: m.kind, distanceKm });
+      else newModalities.push({ kind: m.kind, distanceKm });
+    }
+    const keptIds = new Set(
+      modalities.filter((m) => m.id).map((m) => m.id as string)
+    );
+    const removedModalityIds = data.modalities
+      .map((m) => m.id)
+      .filter((mid) => !keptIds.has(mid));
+
+    setSaving(true);
+    try {
+      await updateEvent({
+        id: data.id,
+        name: name.trim(),
+        description: description.trim(),
+        startDate,
+        endDate,
+        newModalities,
+        updatedModalities,
+        removedModalityIds,
+      });
+      await queryClient.invalidateQueries({ queryKey: ['event', id] });
+      queryClient.invalidateQueries({ queryKey: ['events'] });
+      queryClient.invalidateQueries({ queryKey: ['myCreatedEvents'] });
+      navigate(`/corrida/${data.id}`);
+    } catch (err) {
+      setFormError(
+        gqlErrorMessage(err, 'Não foi possível salvar as mudanças agora.')
+      );
+      setSaving(false);
+    }
+  }
+
+  if (isPending) {
+    return (
+      <main className="mx-auto max-w-4xl px-5 pt-6">
+        <p className="text-papel-suave">Carregando a corrida...</p>
+      </main>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <main className="mx-auto max-w-4xl px-5 pt-6">
+        <p className="text-[#ff6b6b]">
+          {error ? gqlErrorMessage(error) : 'Corrida não encontrada.'}
+        </p>
+        <Link to="/" className="font-semibold text-agua underline">
+          ← Todas as corridas
+        </Link>
+      </main>
+    );
+  }
+
+  // Só a organizadora edita. O servidor também barra (permissões por
+  // `created_by`), mas aqui evitamos mostrar um formulário que não salvaria.
+  if (data.creatorId !== user.id) {
+    return (
+      <main className="mx-auto max-w-4xl px-5 pt-6">
+        <p className="text-papel-suave">
+          Só quem organizou esta corrida pode editá-la.
+        </p>
+        <Link
+          to={`/corrida/${data.id}`}
+          className="font-semibold text-agua underline"
+        >
+          ← Voltar para a corrida
+        </Link>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-5 pb-24 pt-4">
+      <Link
+        to={`/corrida/${data.id}`}
+        className="text-sm font-semibold text-agua no-underline hover:underline"
+      >
+        ← Voltar para a corrida
+      </Link>
+
+      <h1 className="titulo-corrida mt-3">
+        Ajusta a <span className="text-laranja">tua corrida</span>
+      </h1>
+      <p className="mb-7 max-w-lg text-papel-suave">
+        Mude o convite, o período ou as modalidades. Quem já entrou na pista
+        continua inscrito.
+      </p>
+
+      <form onSubmit={handleSubmit} className="max-w-xl rounded-3xl bg-palco p-7">
+        <label className="rotulo" htmlFor="e-nome">
+          Nome da corrida
+        </label>
+        <input
+          id="e-nome"
+          className="campo"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          maxLength={120}
+          placeholder="Ex.: Corrida do Sol Nascente"
+        />
+        <label className="rotulo" htmlFor="e-desc">
+          Convite (descrição)
+        </label>
+        <textarea
+          id="e-desc"
+          className="campo"
+          rows={3}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          required
+          placeholder="Detalhe a corrida e faça a chamada pra galera."
+        />
+
+        <span className="rotulo">Modalidades</span>
+        <div className="flex flex-col gap-2.5">
+          {modalities.map((m, i) => (
+            <div key={m.key} className="flex items-center gap-2">
+              <select
+                aria-label={`Tipo da modalidade ${i + 1}`}
+                className="campo w-auto flex-none"
+                value={m.kind}
+                onChange={(e) =>
+                  updateModality(m.key, {
+                    kind: e.target.value as ModalityKind,
+                  })
+                }
+              >
+                <option value="run">🏃 Corrida</option>
+                <option value="walk">🚶 Caminhada</option>
+              </select>
+              <input
+                aria-label={`Distância da modalidade ${i + 1} em km`}
+                className="campo flex-1"
+                type="number"
+                min="0.5"
+                step="0.1"
+                inputMode="decimal"
+                value={m.distanceKm}
+                onChange={(e) =>
+                  updateModality(m.key, { distanceKm: e.target.value })
+                }
+                required
+                placeholder="km"
+              />
+              {m.inUse ? (
+                <span
+                  aria-label={`Modalidade ${i + 1} já tem inscritos e não pode ser removida`}
+                  title="Já tem gente na pista nesta modalidade"
+                  className="flex-none rounded-full bg-black/25 px-3 py-2 text-sm text-papel-suave"
+                >
+                  🔒
+                </span>
+              ) : (
+                modalities.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => removeModality(m.key)}
+                    aria-label={`Remover modalidade ${i + 1}`}
+                    className="flex-none rounded-full bg-black/25 px-3 py-2 text-sm text-papel hover:bg-black/40"
+                  >
+                    ✕
+                  </button>
+                )
+              )}
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={addModality}
+          className="mt-2.5 rounded-full border-2 border-roxo-claro px-4 py-1.5 text-sm font-semibold text-papel-suave hover:border-agua hover:text-agua"
+        >
+          + Mais uma modalidade
+        </button>
+
+        <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div>
+            <label className="rotulo" htmlFor="e-ini">
+              Começa em
+            </label>
+            <input
+              id="e-ini"
+              className="campo"
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label className="rotulo" htmlFor="e-fim">
+              Termina em
+            </label>
+            <input
+              id="e-fim"
+              className="campo"
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              required
+            />
+          </div>
+        </div>
+
+        {formError && <p className="mt-3 text-sm text-[#ff6b6b]">{formError}</p>}
+
+        <div className="mt-5 flex flex-wrap items-center gap-3">
+          <button type="submit" disabled={saving} className="btn-corrida">
+            {saving ? 'Salvando...' : 'Salvar mudanças ✨'}
+          </button>
+          <Link
+            to={`/corrida/${data.id}`}
+            className="font-semibold text-papel-suave hover:text-papel"
+          >
+            Cancelar
+          </Link>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/src/pages/EventList.tsx
+++ b/src/pages/EventList.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { listEvents } from '../api/events';
 import { gqlErrorMessage } from '../api/graphql';
 import { useUser } from '../contexts/Auth';
@@ -7,7 +7,6 @@ import { dateRangeParts, groupModalities, posterGradient } from '../utils';
 
 export default function EventList() {
   const user = useUser();
-  const navigate = useNavigate();
   const { data, error, isPending } = useQuery({
     queryKey: ['events', user.id],
     queryFn: () => listEvents(user.id),
@@ -40,14 +39,28 @@ export default function EventList() {
           {data.map((event, i) => {
             const dt = dateRangeParts(event.startDate, event.endDate);
             const groups = groupModalities(event.modalities);
+            const mine = event.creatorId === user.id;
             return (
-              <button
+              <div
                 key={event.id}
-                type="button"
-                onClick={() => navigate(`/corrida/${event.id}`)}
-                className={`${posterGradient(i)} flex min-h-[190px] flex-col overflow-hidden rounded-[22px] text-left transition-transform hover:-rotate-1 hover:scale-[1.015] motion-reduce:transform-none`}
+                className={`${posterGradient(i)} relative flex min-h-[190px] flex-col overflow-hidden rounded-[22px] text-left transition-transform hover:-rotate-1 hover:scale-[1.015] motion-reduce:transform-none`}
               >
-                <div className="flex flex-1 gap-3.5 p-4">
+                <Link
+                  to={`/corrida/${event.id}`}
+                  aria-label={`Abrir ${event.name}`}
+                  className="absolute inset-0 z-0"
+                />
+                {mine && (
+                  <Link
+                    to={`/corrida/${event.id}/editar`}
+                    aria-label={`Editar ${event.name}`}
+                    title="Editar corrida"
+                    className="absolute right-2.5 top-2.5 z-10 inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/30 text-base text-white no-underline transition hover:bg-black/50"
+                  >
+                    ✏️
+                  </Link>
+                )}
+                <div className="relative z-0 flex flex-1 gap-3.5 p-4">
                   <div className="flex flex-none flex-col items-center justify-center rounded-2xl bg-black/25 px-3 py-2.5 text-papel">
                     <span className="font-display text-2xl leading-none">
                       {dt.startDay}
@@ -107,7 +120,7 @@ export default function EventList() {
                     {event.amRegistered ? 'você tá dentro ✓' : 'entrar →'}
                   </span>
                 </span>
-              </button>
+              </div>
             );
           })}
         </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface EventSummary {
   registrationCount: number;
   completedCount: number;
   amRegistered: boolean;
+  creatorId: string;
 }
 
 export interface EventRegistration {
@@ -44,6 +45,7 @@ export interface EventDetail {
   modalities: Modality[];
   startDate: string;
   endDate: string;
+  creatorId: string;
   creatorName: string | null;
   registrations: EventRegistration[];
 }


### PR DESCRIPTION
Quem criou a corrida passa a poder alterá-la: nome, convite, período e
modalidades (editar, adicionar, remover). Modalidade com gente inscrita fica
travada contra remoção para não órfã as medalhas.

- Nova página EventEdit em /corrida/:id/editar, protegida e restrita ao
  organizador (checagem no cliente; o servidor também barra por created_by).
- Entradas de edição: botão no detalhe e caneta no card da listagem, ambos só
  para o organizador. Card da listagem virou container com link esticado +
  link de edição sobreposto (sem aninhar elementos interativos).
- API: updateEvent numa única mutation transacional (evento + upsert/insert/
  delete de modalidades). Queries passam a trazer created_by (creatorId).
- Hasura: permissao de update em events e update+delete em event_modalities,
  travadas em created_by. Sem mudanca de schema (colunas ja existem).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ur4mQ2ZJJNWXRRHBCwVx4C